### PR TITLE
Forward TensorBoard logger version and verify checkpoint discovery

### DIFF
--- a/tests/test_logging_paths.py
+++ b/tests/test_logging_paths.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from pytorch_lightning.loggers import TensorBoardLogger
+
+from test_dqn import find_best_checkpoint
+
+
+def test_tensorboard_logger_respects_explicit_version(tmp_path):
+    """Specifying a logger version should influence both logging and checkpoint paths."""
+
+    log_dir = tmp_path / "lightning_logs"
+    logger_name = "dqn_agent"
+    version = 7
+    checkpoint_subdir = "checkpoints"
+
+    logger = TensorBoardLogger(
+        save_dir=str(log_dir),
+        name=logger_name,
+        version=version,
+    )
+
+    expected_log_dir = log_dir / logger_name / f"version_{version}"
+    assert Path(logger.log_dir) == expected_log_dir
+
+    checkpoint_dir = expected_log_dir / checkpoint_subdir
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    checkpoint_path = checkpoint_dir / "dummy.ckpt"
+    checkpoint_path.write_text("checkpoint content", encoding="utf-8")
+
+    found_checkpoint = find_best_checkpoint(
+        log_dir=log_dir,
+        logger_name=logger_name,
+        checkpoint_subdir=checkpoint_subdir,
+        versions=[expected_log_dir],
+    )
+
+    assert found_checkpoint == checkpoint_path

--- a/train_dqn.py
+++ b/train_dqn.py
@@ -54,9 +54,11 @@ def main():
         iou_threshold=env_cfg.get("iou_threshold", 0.8),
     )
 
+    logger_version = logging_cfg.get("version")
     logger = TensorBoardLogger(
         save_dir=logging_cfg.get("log_dir", "lightning_logs"),
         name=logging_cfg.get("logger_name", "dqn_agent"),
+        version=logger_version,
     )
 
     checkpoint_subdir = Path(logging_cfg.get("checkpoint_dir", "checkpoints")).name


### PR DESCRIPTION
## Summary
- pass the configured logging version through to the TensorBoard logger so explicit versions map to the expected directory structure
- keep checkpoint exports nested beneath the logger's log directory when versions are specified
- add a smoke test that ensures the logger creates the requested version directory and that `test_dqn` finds checkpoints there

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf64fdcdc083209c7a165b581e733c