### PR TITLE
Support tumour-free slices in data pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ MU-Glioma-Post/
 -   **Image Files:** Should contain `_brain_t1c.nii.gz` in their filename.
 -   **Mask Files:** Should contain `_tumorMask.nii.gz` in their filename.
 
+You can control whether tumour-free slices are included in the training data via the `include_empty_masks` flag in `config.yaml`.
+Enabling this option keeps slices whose masks sum to zero so that the reinforcement learning agent observes a mix of positive and
+negative cases during experience replay.
+
 ## Usage
 
 ### DQN Training

--- a/config.yaml
+++ b/config.yaml
@@ -6,6 +6,7 @@ data:
   pin_memory: true
   val_split: 0.1
   test_split: 0.1
+  include_empty_masks: false
 
 training:
   batch_size: 16

--- a/data/data_module.py
+++ b/data/data_module.py
@@ -20,6 +20,7 @@ class BrainTumorDataModule(pl.LightningDataModule):
         val_split: float = 0.1,
         test_split: float = 0.1,
         seed: int = 42,
+        include_empty_masks: bool = False,
     ) -> None:
         super().__init__()
         self.data_dir = data_dir
@@ -31,6 +32,7 @@ class BrainTumorDataModule(pl.LightningDataModule):
         self.test_split = max(0.0, float(test_split))
         self.seed = seed
         self.transform = None  # Add your transforms here if needed
+        self.include_empty_masks = bool(include_empty_masks)
 
         self.train_dataset = None
         self.val_dataset = None
@@ -40,7 +42,11 @@ class BrainTumorDataModule(pl.LightningDataModule):
         if stage not in (None, "fit", "validate", "test"):
             return
 
-        dataset = BrainTumorDataset(self.data_dir, transform=self.transform)
+        dataset = BrainTumorDataset(
+            self.data_dir,
+            transform=self.transform,
+            include_empty_masks=self.include_empty_masks,
+        )
         total_samples = len(dataset)
         if total_samples == 0:
             raise RuntimeError("BrainTumorDataset is empty. Please verify the dataset path and contents.")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,55 @@
+import numpy as np
+import nibabel as nib
+import torch
+
+from data.dataset import BrainTumorDataset
+from data.data_module import BrainTumorDataModule
+
+
+def _create_mock_dataset(root_path):
+    patient_dir = root_path / "patient_0001" / "timepoint_01"
+    patient_dir.mkdir(parents=True)
+
+    image = np.zeros((4, 4, 2), dtype=np.float32)
+    mask = np.zeros((4, 4, 2), dtype=np.float32)
+    mask[:, :, 1] = 1.0
+
+    image_path = patient_dir / "patient_0001_timepoint_01_brain_t1c.nii.gz"
+    mask_path = patient_dir / "patient_0001_timepoint_01_tumorMask.nii.gz"
+
+    nib.save(nib.Nifti1Image(image, affine=np.eye(4)), str(image_path))
+    nib.save(nib.Nifti1Image(mask, affine=np.eye(4)), str(mask_path))
+
+
+def test_dataset_can_include_empty_slices(tmp_path):
+    _create_mock_dataset(tmp_path)
+
+    dataset_without_empty = BrainTumorDataset(str(tmp_path), include_empty_masks=False)
+    dataset_with_empty = BrainTumorDataset(str(tmp_path), include_empty_masks=True)
+
+    assert len(dataset_without_empty) == 1
+    assert len(dataset_with_empty) == 2
+
+    mask_sums = {torch.sum(sample["mask"]).item() for sample in dataset_with_empty}
+    assert 0.0 in mask_sums
+
+
+def test_datamodule_exposes_negative_samples_when_enabled(tmp_path):
+    _create_mock_dataset(tmp_path)
+
+    data_module = BrainTumorDataModule(
+        data_dir=str(tmp_path),
+        batch_size=1,
+        val_split=0.0,
+        test_split=0.0,
+        include_empty_masks=True,
+    )
+
+    data_module.setup()
+
+    train_loader = data_module.train_dataloader()
+    batches = list(train_loader)
+    assert len(batches) >= 1
+
+    mask_sums = {torch.sum(batch["mask"]).item() for batch in batches}
+    assert 0.0 in mask_sums

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,0 +1,32 @@
+import pytest
+import torch
+
+from dqn.environment import TumorLocalizationEnv
+
+
+def _no_tumor_batch(batch_size=1):
+    images = torch.zeros(batch_size, 3, 84, 84)
+    masks = torch.zeros(batch_size, 1, 84, 84)
+    return images, masks
+
+
+def test_no_tumor_stop_action_reward():
+    env = TumorLocalizationEnv(max_steps=5, iou_threshold=0.5)
+    images, masks = _no_tumor_batch()
+    env.reset(images, masks)
+
+    _, rewards, done, _ = env.step(torch.tensor([env._STOP_ACTION]))
+
+    assert rewards.item() == pytest.approx(2.0)
+    assert done.item()
+
+
+def test_no_tumor_continue_action_penalty():
+    env = TumorLocalizationEnv(max_steps=5, iou_threshold=0.5)
+    images, masks = _no_tumor_batch()
+    env.reset(images, masks)
+
+    _, rewards, done, _ = env.step(torch.tensor([0]))
+
+    assert rewards.item() == pytest.approx(-0.5)
+    assert not done.item()

--- a/train_dqn.py
+++ b/train_dqn.py
@@ -31,6 +31,7 @@ def main():
         val_split=data_cfg.get("val_split", 0.1),
         test_split=data_cfg.get("test_split", 0.1),
         seed=training_cfg.get("seed", 42),
+        include_empty_masks=data_cfg.get("include_empty_masks", False),
     )
 
     model = DQNLightning(


### PR DESCRIPTION
## Summary
- add an `include_empty_masks` toggle to the dataset so tumour-free slices can be kept
- thread the option through the Lightning data module, configuration and training entry point with documentation updates
- add regression tests covering dataset mixing behaviour and the environment's no-tumour reward path

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf6515500c83209b104db885ef02af