### PR TITLE
Add gt-margin initialization mode for tumor localization env

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -59,3 +59,17 @@ def test_no_tumor_continue_action_penalty():
 
     assert rewards.item() == pytest.approx(-0.5)
     assert not done.item()
+
+
+def test_gt_margin_initialisation_allows_movement():
+    env = TumorLocalizationEnv(initial_mode="gt_margin", initial_margin=5.0, step_size=5.0)
+    images = torch.zeros(1, 3, 84, 84)
+    masks = torch.zeros(1, 1, 84, 84)
+    masks[:, :, 30:40, 30:40] = 1.0
+
+    _, bboxes = env.reset(images, masks)
+    initial_bbox = bboxes.clone()
+
+    (_, updated_bboxes), _, _, _ = env.step(torch.tensor([3]))
+
+    assert updated_bboxes[0, 0] > initial_bbox[0, 0]


### PR DESCRIPTION
## Summary
- add a configurable `gt_margin` initialisation mode that expands tumour boxes while keeping space to move and falls back to the image frame when no tumour is present
- expose the initialisation mode and margin on `TumorLocalizationEnv`
- add a regression test ensuring a movement action changes the bounding box immediately after reset when using the new mode

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf7104bff08320a79f5fbc2012fc45