### PR TITLE
Prune unused parameters and simplify data splitting

### DIFF
--- a/dqn/agent.py
+++ b/dqn/agent.py
@@ -14,7 +14,6 @@ class DQNAgent:
         policy_net,
         target_net,
         num_actions,
-        learning_rate: float = 1e-4,
         gamma: float = 0.99,
         epsilon_start: float = 1.0,
         epsilon_end: float = 0.05,
@@ -24,7 +23,6 @@ class DQNAgent:
         target_update: int = 10,
     ) -> None:
         self.num_actions = num_actions
-        self.learning_rate = learning_rate
         self.gamma = gamma
         self.epsilon_start = epsilon_start
         self.epsilon_end = epsilon_end
@@ -36,7 +34,6 @@ class DQNAgent:
         self.target_net = target_net
 
         self.memory = ReplayMemory(memory_size)
-        self.steps_done = 0
         self.current_epsilon = max(0.0, epsilon_start)
         if self.epsilon_start <= 0:
             self._step_decay = 1.0
@@ -47,9 +44,6 @@ class DQNAgent:
     @property
     def device(self) -> torch.device:
         return next(self.policy_net.parameters()).device
-
-    def reset_memory(self) -> None:
-        self.memory = ReplayMemory(self.memory.capacity)
 
     def set_episode_progress(self, episode_idx: int, total_episodes: Optional[int]) -> None:
         """Update epsilon-greedy exploration schedule for a new episode."""
@@ -86,7 +80,6 @@ class DQNAgent:
         random_actions = torch.randint(0, self.num_actions, (batch_size,), device=self.device)
         selected_actions = torch.where(random_mask, random_actions, greedy_actions)
 
-        self.steps_done += batch_size
         self.current_epsilon = max(self.epsilon_end, self.current_epsilon * self._step_decay)
         return selected_actions.detach()
 

--- a/dqn/lightning_model.py
+++ b/dqn/lightning_model.py
@@ -16,7 +16,6 @@ class DQNLightning(pl.LightningModule):
 
     def __init__(
         self,
-        data_dir: str,
         batch_size: int = 16,
         lr: float = 1e-4,
         gamma: float = 0.99,
@@ -28,7 +27,6 @@ class DQNLightning(pl.LightningModule):
         max_steps: int = 100,
         grad_clip: float = 1.0,
         lr_gamma: float = 0.995,
-        seed: int = 42,
         val_interval: int = 1,
         test_gif_limit: int = 10,
         test_gif_dir: str = "lightning_logs/test_gifs",
@@ -48,7 +46,6 @@ class DQNLightning(pl.LightningModule):
             policy_net=self.policy_net,
             target_net=self.target_net,
             num_actions=9,
-            learning_rate=self.hparams.lr,
             gamma=self.hparams.gamma,
             epsilon_start=self.hparams.eps_start,
             epsilon_end=self.hparams.eps_end,
@@ -218,7 +215,6 @@ class DQNLightning(pl.LightningModule):
         batch: Dict[str, torch.Tensor],
         greedy: bool,
         record: bool,
-        record_index: int = 0,
     ) -> Tuple[Dict[str, torch.Tensor], Optional[list]]:
         images = batch["image"].to(self.device, non_blocking=True)
         masks = batch["mask"].to(self.device, non_blocking=True)
@@ -232,7 +228,7 @@ class DQNLightning(pl.LightningModule):
         frames = []
 
         if record:
-            frames.append(env.render(index=record_index, mode="rgb_array"))
+            frames.append(env.render(index=0, mode="rgb_array"))
 
         for _ in range(self.hparams.max_steps):
             actions = self.agent.select_action(state, greedy=greedy)
@@ -246,7 +242,7 @@ class DQNLightning(pl.LightningModule):
             state = next_state
 
             if record:
-                frames.append(env.render(index=record_index, mode="rgb_array"))
+                frames.append(env.render(index=0, mode="rgb_array"))
 
             active_mask = active_mask & ~done.to(self.device)
             if not active_mask.any():

--- a/test_dqn.py
+++ b/test_dqn.py
@@ -118,8 +118,6 @@ def main():
         total_reward += float(rewards[0].item())
         state = next_state
 
-    env.close()
-
     output_dir = Path(logging_cfg.get("test_gif_dir", "lightning_logs/test_gifs"))
     output_dir.mkdir(parents=True, exist_ok=True)
     video_path = output_dir / "dqn_test_episode.gif"

--- a/train_dqn.py
+++ b/train_dqn.py
@@ -35,7 +35,6 @@ def main():
     )
 
     model = DQNLightning(
-        data_dir=data_cfg.get("data_dir", "MU-Glioma-Post/"),
         batch_size=training_cfg.get("batch_size", data_cfg.get("batch_size", 16)),
         lr=training_cfg.get("lr", 1e-4),
         gamma=training_cfg.get("gamma", 0.99),
@@ -47,7 +46,6 @@ def main():
         max_steps=training_cfg.get("max_steps", 100),
         grad_clip=training_cfg.get("grad_clip", 1.0),
         lr_gamma=training_cfg.get("lr_gamma", 0.995),
-        seed=training_cfg.get("seed", 42),
         val_interval=training_cfg.get("val_interval", 1),
         test_gif_limit=logging_cfg.get("test_gif_limit", 10),
         test_gif_dir=logging_cfg.get("test_gif_dir", "lightning_logs/test_gifs"),


### PR DESCRIPTION
## Summary
- remove unused DQN LightningModule hyperparameters and dead agent attributes while simplifying environment simulation recording
- streamline BrainTumorDataModule.setup by splitting datasets directly from ratio-derived lengths
- align training and evaluation scripts with the leaner interfaces and remove the invalid environment close call

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf74be44088320843ff03519ba6b62